### PR TITLE
Moved sendNewOtpToUser() from middleware middleware to facade

### DIFF
--- a/src/Http/Middleware/Otp.php
+++ b/src/Http/Middleware/Otp.php
@@ -12,7 +12,6 @@ use Illuminate\Http\Request;
 use Erdemkeren\Otp\OtpFacade;
 use Erdemkeren\Otp\TokenInterface;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Contracts\Auth\Authenticatable;
 
 class Otp
 {

--- a/src/Http/Middleware/Otp.php
+++ b/src/Http/Middleware/Otp.php
@@ -34,7 +34,7 @@ class Otp
         }
 
         if (! $request->hasCookie('otp_token')) {
-            $this->sendNewOtpToUser($user);
+            OtpFacade::sendNewOtpToUser($user);
 
             return $this->redirectToOtpPage();
         }
@@ -45,7 +45,7 @@ class Otp
         );
 
         if (! $token || $token->expired()) {
-            $this->sendNewOtpToUser($user);
+            OtpFacade::sendNewOtpToUser($user);
 
             return $this->redirectToOtpPage();
         }
@@ -70,23 +70,5 @@ class Otp
         ]);
 
         return redirect()->route('otp.create');
-    }
-
-    /**
-     * Create a new otp and notify the user.
-     *
-     * @param Authenticatable $user
-     */
-    private function sendNewOtpToUser(Authenticatable $user): void
-    {
-        $token = OtpFacade::create($user, 6);
-
-        if (! method_exists($user, 'notify')) {
-            throw new \UnexpectedValueException(
-                'The otp owner should be an instance of notifiable or implement the notify method.'
-            );
-        }
-
-        $user->notify($token->toNotification());
     }
 }

--- a/src/Http/Middleware/Otp.php
+++ b/src/Http/Middleware/Otp.php
@@ -8,10 +8,10 @@
 namespace Erdemkeren\Otp\Http\Middleware;
 
 use Closure;
-use Illuminate\Http\Request;
 use Erdemkeren\Otp\OtpFacade;
 use Erdemkeren\Otp\TokenInterface;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 
 class Otp
 {

--- a/src/OtpFacade.php
+++ b/src/OtpFacade.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static check($authenticableId, string $token): bool
  * @method static addPasswordGenerator(string $name, $generator): void
  * @method static create($authenticatableId, ?int $length = null): TokenInterface
+ * @method static sendNewOtpToUser(Authenticatable $user): void
  * @method static retrieveByPlainText($authenticableId, string $plainText): ?TokenInterface
  * @method static retrieveByCipherText($authenticableId, string $cipherText): ?TokenInterface
  */

--- a/src/OtpService.php
+++ b/src/OtpService.php
@@ -147,6 +147,24 @@ class OtpService
     }
 
     /**
+     * Create a new otp and notify the user.
+     *
+     * @param Authenticatable $user
+     */
+    public function sendNewOtpToUser(Authenticatable $user): void
+    {
+        $token = OtpFacade::create($user, 6);
+
+        if (! method_exists($user, 'notify')) {
+            throw new \UnexpectedValueException(
+                'The otp owner should be an instance of notifiable or implement the notify method.'
+            );
+        }
+
+        $user->notify($token->toNotification());
+    }
+
+    /**
      * Retrieve the token of the authenticable
      * by the given plain text.
      *


### PR DESCRIPTION
`sendNewOtpToUser()` should not be on the middleware but in the facade so it can be used for other purposes.

With this commit this method should be callable anywhere by `app('otp')->sendNewOtpToUser($user)`