### PR TITLE
Changing private methods to protected so they can be extended eventually

### DIFF
--- a/src/Http/Controllers/OtpController.php
+++ b/src/Http/Controllers/OtpController.php
@@ -92,7 +92,7 @@ class OtpController
      *
      * @return ValidatorInterface
      */
-    private function getOtpSubmissionRequestValidator(Request $request): ValidatorInterface
+    protected function getOtpSubmissionRequestValidator(Request $request): ValidatorInterface
     {
         return ValidatorFacade::make($request->all(), [
             'password' => 'required|string',
@@ -107,7 +107,7 @@ class OtpController
      *
      * @return mixed
      */
-    private function retrieveOtpTokenByPlainText(Authenticatable $user, string $password): ?TokenInterface
+    protected function retrieveOtpTokenByPlainText(Authenticatable $user, string $password): ?TokenInterface
     {
         return Otp::retrieveByPlainText($user, $password);
     }
@@ -117,7 +117,7 @@ class OtpController
      *
      * @return mixed
      */
-    private function otpHasBeenRequested()
+    protected function otpHasBeenRequested()
     {
         return session('otp_requested', false);
     }

--- a/src/Http/Middleware/Otp.php
+++ b/src/Http/Middleware/Otp.php
@@ -77,7 +77,7 @@ class Otp
      *
      * @param Authenticatable $user
      */
-    private function sendNewOtpToUser(Authenticatable $user): void
+    protected function sendNewOtpToUser(Authenticatable $user): void
     {
         $token = OtpFacade::create($user, 6);
 

--- a/src/OtpService.php
+++ b/src/OtpService.php
@@ -197,7 +197,7 @@ class OtpService
      *
      * @return callable
      */
-    private function getPasswordGenerator(): callable
+    protected function getPasswordGenerator(): callable
     {
         return $this->passwordGenerator ?: $this->passwordGenerator = $this->manager->get($this->defaultGenerator);
     }

--- a/src/OtpServiceProvider.php
+++ b/src/OtpServiceProvider.php
@@ -62,7 +62,7 @@ class OtpServiceProvider extends ServiceProvider
      *
      * @return OtpService
      */
-    private function createServiceInstance(): OtpService
+    protected function createServiceInstance(): OtpService
     {
         return new OtpService(
             new PasswordGeneratorManager(),
@@ -79,7 +79,7 @@ class OtpServiceProvider extends ServiceProvider
      *
      * @param OtpService $service
      */
-    private function registerDefaultPasswordGenerators($service): void
+    protected function registerDefaultPasswordGenerators($service): void
     {
         $service->addPasswordGenerator('string', Generators\StringPasswordGenerator::class);
         $service->addPasswordGenerator('numeric', Generators\NumericPasswordGenerator::class);
@@ -91,7 +91,7 @@ class OtpServiceProvider extends ServiceProvider
      *
      * @return string
      */
-    private function configPath()
+    protected function configPath()
     {
         return __DIR__.'/../config/otp.php';
     }
@@ -101,7 +101,7 @@ class OtpServiceProvider extends ServiceProvider
      *
      * @return string
      */
-    private function migrationPath()
+    protected function migrationPath()
     {
         return __DIR__.'/../database/migrations/';
     }
@@ -111,7 +111,7 @@ class OtpServiceProvider extends ServiceProvider
      *
      * @return string
      */
-    private function viewPath()
+    protected function viewPath()
     {
         return __DIR__.'/../views/';
     }

--- a/src/PasswordGeneratorManager.php
+++ b/src/PasswordGeneratorManager.php
@@ -70,7 +70,7 @@ final class PasswordGeneratorManager implements PasswordGeneratorManagerInterfac
      *
      * @return PasswordGeneratorInterface
      */
-    private function createGeneratorFromString(string $className): PasswordGeneratorInterface
+    protected function createGeneratorFromString(string $className): PasswordGeneratorInterface
     {
         if (! class_exists($className)) {
             throw new \RuntimeException(

--- a/src/PasswordGenerators/NumericNo0PasswordGenerator.php
+++ b/src/PasswordGenerators/NumericNo0PasswordGenerator.php
@@ -32,7 +32,7 @@ class NumericNo0PasswordGenerator extends NumericPasswordGenerator implements Pa
      *
      * @return int
      */
-    private function getRandomDigitWithNo0()
+    protected function getRandomDigitWithNo0()
     {
         try {
             $int = random_int(1, 9);

--- a/src/Token.php
+++ b/src/Token.php
@@ -314,7 +314,7 @@ class Token implements TokenInterface
      *
      * @return Carbon
      */
-    private function getNow(): Carbon
+    protected function getNow(): Carbon
     {
         return Carbon::now();
     }
@@ -324,7 +324,7 @@ class Token implements TokenInterface
      *
      * @return string
      */
-    private static function getTable(): string
+    protected static function getTable(): string
     {
         return config('otp.table');
     }
@@ -334,7 +334,7 @@ class Token implements TokenInterface
      *
      * @return int
      */
-    private function getDefaultExpiryTime(): int
+    protected function getDefaultExpiryTime(): int
     {
         return config('otp.expires') * 60;
     }


### PR DESCRIPTION
Often I had to extend some files, however private methods were not allowing me to redeclare some methods.
For this purpose I changed all methods from private to protected.